### PR TITLE
Fix override time being cast as string.

### DIFF
--- a/bin/pgtools
+++ b/bin/pgtools
@@ -51,7 +51,7 @@ subcommands = {
     This code is used to temporarily override the primary person on-call for a given schedule.
 
     EOS
-    
+
     opts.on('-e', '--email EMAIL', 'Specify email address of override user') do |e|
       options[:email] = e
     end
@@ -59,7 +59,7 @@ subcommands = {
       options[:schedule_name] = s
     end
     opts.on('-t', '--override-length TIME', 'Number of seconds to maintain override for') do |t|
-      options[:override_length] = t
+      options[:override_length] = t.to_i
     end
   end,
 

--- a/pagerduty_tools.gemspec
+++ b/pagerduty_tools.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'pagerduty_tools'
-  s.version     = '0.0.1alpha14'
+  s.version     = '0.0.1alpha15'
   s.date        = '2014-11-25'
   s.summary     = 'TapJoy PagerDuty Tools'
   s.description = 'A set of tools to make leveraging the PagerDuty APIs easier'


### PR DESCRIPTION
@Tapjoy/opsautomation @atayarani override_time was getting passed in as a string by default from the cli, so this allows the needed math to take place. 
