### PR TITLE
add time window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+v0.3.2
+==
+* Allow users to specify audit window
+
+v0.3.1
+==
+Note: v0.3.0 was skipped
+* Add ability to view last 30 days of incidents
+
 v0.2.0
 ==
 * Switch out optparse for trollop, which make the code significantly more readable

--- a/README.md
+++ b/README.md
@@ -94,12 +94,17 @@ hash as specified in 'triggers.yaml'
 
 ### audit
 
-This script will return the last 30 days of pages or last 100 pages, which ever is fewer.  There are no options available for this command at this time.
+By default, this script will return the last 30 days of pages or last 100 pages, which ever is fewer.  There are parameters to adjust the date range, but 100 pages is still the cap.
 
 For more information on the output of this command: https://developer.pagerduty.com/documentation/rest/incidents/list
 
 ```
-Usage: pgutils audit
+  Usage: pgutils audit
+
+  Options:
+    -s, --since=<i>    Get list of incidents since the given time window in days (default: 30)
+    -u, --until=<i>    Get list of incidents until the given time window in days relative to since parameter (default: 30)
+    -h, --help         Show this message
 ```
 
 ## Example Uses

--- a/bin/pgutils
+++ b/bin/pgutils
@@ -71,12 +71,14 @@ when 'get_on_call'
     puts '---'
   end
 when 'audit'
-  Trollop::options do
+  opts = Trollop::options do
     usage 'audit'
-    synopsis "\nThis script will return the last 30 days of pages or last 100 pages, which ever is fewer.\nThere are no options available for this command at this time."
+    opt :since, 'Get list of incidents since the given time window in days', default: 30, type: :int
+    opt :until, 'Get list of incidents until the given time window in days relative to since parameter', default: 30, type: :int
+    synopsis "\nBy default, this script will return the last 30 days of pages or last 100 pages, which ever is fewer.\nThere are parameters to adjust the date range, but 100 pages is still the cap."
   end
 
-  incidents = Tapjoy::PagerDuty::Base.new.get_incidents
+  incidents = Tapjoy::PagerDuty::Base.new.get_incidents(query_start: opts[:since], query_end: opts[:until])
   puts incidents['incidents'].to_yaml
   puts "Total Alerts: #{incidents['total']}"
 

--- a/lib/tapjoy/pagerduty/base.rb
+++ b/lib/tapjoy/pagerduty/base.rb
@@ -9,8 +9,8 @@ module Tapjoy
         pg_conn = YAML.load_file(config_file) if File.readable?(config_file)
 
         @AUTH_HEADER = {
-          :subdomain    => ENV['PAGERDUTY_SUBDOMAIN'] || pg_conn[:subdomain],
-          :token_string => "Token token=#{ENV['PAGERDUTY_API_TOKEN'] || pg_conn[:api_token]}"
+          subdomain:    ENV['PAGERDUTY_SUBDOMAIN'] || pg_conn[:subdomain],
+          token_string: "Token token=#{ENV['PAGERDUTY_API_TOKEN'] || pg_conn[:api_token]}"
         }
 
         raise 'Missing subdomain value' if @AUTH_HEADER[:subdomain].nil?
@@ -82,8 +82,10 @@ module Tapjoy
         post_object(endpoint, data)
       end
 
-      def get_incidents
-        endpoint = return_pagerduty_url(:incidents)
+      def get_incidents(query_start:, query_end:)
+        since_date = Date.today - query_start
+        until_date = since_date + query_end
+        endpoint = "#{return_pagerduty_url(:incidents)}?since=#{since_date}&until=#{until_date}"
         return get_object(endpoint)
       end
 

--- a/lib/tapjoy/pagerduty/version.rb
+++ b/lib/tapjoy/pagerduty/version.rb
@@ -3,7 +3,7 @@ module Tapjoy
     module Version
       MAJOR = 0
       MINOR = 3
-      PATCH = 1
+      PATCH = 2
     end
 
     VERSION = [Version::MAJOR, Version::MINOR, Version::PATCH].join('.')

--- a/pagerduty_utils.gemspec
+++ b/pagerduty_utils.gemspec
@@ -2,7 +2,7 @@ require File.expand_path('../lib/tapjoy/pagerduty/version', __FILE__)
 Gem::Specification.new do |s|
   s.name        = 'pagerduty_utils'
   s.version     = Tapjoy::PagerDuty::VERSION
-  s.date        = '2015-04-22'
+  s.date        = '2015-05-26'
   s.summary     = 'Tapjoy PagerDuty Tools'
   s.description = 'A set of tools to make leveraging the PagerDuty APIs easier'
   s.authors     = ['Ali Tayarani', 'Ed Healy']


### PR DESCRIPTION
@Tapjoy/eng-group-ops 
@nwmartin

Notes:
* This allows us to get a specific window of audits, which is why until_date is relative to since_date